### PR TITLE
Fix #713 : now it is possible to create alias with tag (+) in recipient ...

### DIFF
--- a/modoboa/extensions/admin/tests/alias.py
+++ b/modoboa/extensions/admin/tests/alias.py
@@ -62,6 +62,26 @@ class AliasTestCase(ModoTestCase):
             "titi@test.com"
         )
 
+    def test_append_alias_with_tag(self):
+        """Try to create a alias with tag in recipient address"""
+        user = User.objects.get(username="user@test.com")
+        values = dict(
+            username="user@test.com", role=user.group,
+            is_active=user.is_active, email="user@test.com"
+        )
+        self.ajax_post(
+            reverse("admin:account_change", args=[user.id]),
+            values
+        )
+
+        values = {
+            "email": "foobar@test.com", "recipients": "user+spam@test.com",
+            "enabled": True
+        }
+        self.ajax_post(reverse("admin:alias_add"), values)
+        alias = Alias.objects.get(address="foobar", domain__name="test.com")
+        self.assertEqual(alias.extmboxes, "user+spam@test.com")
+
     def test_dlist(self):
         values = dict(email="all@test.com",
                       recipients="user@test.com",


### PR DESCRIPTION
now it is possible to create alias with tag (+) in recipient address with internal domain. See #713 