### PR TITLE
Fix remote_addr if modoboa django app is powered by apache or nginx proxy

### DIFF
--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -78,6 +78,7 @@ INSTALLED_APPS += MODOBOA_APPS
 AUTH_USER_MODEL = 'core.User'
 
 MIDDLEWARE_CLASSES = (
+    'x_forwarded_for.middleware.XForwardedForMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ factory-boy<2.4
 passlib
 django-versionfield2>=0.3.3
 requests
+django-xforwardedfor-middleware


### PR DESCRIPTION
Fix remote_addr if modoboa django app is powered by apache or nginx proxy