### PR TITLE
Fix typo, revise German translation

### DIFF
--- a/modoboa/core/app_settings.py
+++ b/modoboa/core/app_settings.py
@@ -80,7 +80,7 @@ class GeneralParametersForm(parameters.AdminParametersForm):
         label=ugettext_lazy("Server address"),
         initial="localhost",
         help_text=ugettext_lazy(
-            "The IP address of the DNS name of the LDAP server"),
+            "The IP address or the DNS name of the LDAP server"),
         widget=forms.TextInput(attrs={"class": "form-control"})
     )
 

--- a/modoboa/locale/cs_CZ/LC_MESSAGES/django.po
+++ b/modoboa/locale/cs_CZ/LC_MESSAGES/django.po
@@ -102,7 +102,7 @@ msgid "Server address"
 msgstr "Adresa serveru"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
 msgstr "IP adresa DNS jména LDAP serveru"
 
 #: core/app_settings.py:88

--- a/modoboa/locale/de/LC_MESSAGES/django.po
+++ b/modoboa/locale/de/LC_MESSAGES/django.po
@@ -103,8 +103,8 @@ msgid "Server address"
 msgstr "Server-Adresse"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
-msgstr "Die IP-Adresse des LDAP-Server Hostnamens"
+msgid "The IP address or the DNS name of the LDAP server"
+msgstr "IP-Adresse oder Hostname des LDAP-Servers"
 
 #: core/app_settings.py:88
 msgid "Server port"
@@ -363,8 +363,7 @@ msgstr "Der normale Benutzer '%s' muss eine gültige E-Mail-Adresse besitzen"
 #, python-format
 msgid "username and email fields must not differ for '%s'"
 msgstr ""
-"Die Felder für Benutzername und E-Mail für '%s' dürfen sich nicht "
-"unterscheiden"
+"Benutzername und E-Mail für '%s' dürfen sich nicht unterscheiden"
 
 #: core/models.py:465
 msgid "added"
@@ -638,11 +637,11 @@ msgstr "Schließen"
 
 #: templates/common/wizard_forms.html:31
 msgid "Previous"
-msgstr "Vorheriges"
+msgstr "Zurück"
 
 #: templates/common/wizard_forms.html:32
 msgid "Next"
-msgstr "Nächstes"
+msgstr "Weiter"
 
 #: templates/registration/login.html:10
 msgid "Welcome to Modoboa"

--- a/modoboa/locale/de/LC_MESSAGES/djangojs.po
+++ b/modoboa/locale/de/LC_MESSAGES/djangojs.po
@@ -22,7 +22,7 @@ msgstr ""
 
 #: core/static/core/js/settings.js:14
 msgid "No more log entry to show"
-msgstr "Keine weiteren log eintrage"
+msgstr "Keine weiteren Log-Einträge"
 
 #: static/js/confirmation.js:44
 msgid "Warning"

--- a/modoboa/locale/en/LC_MESSAGES/django.po
+++ b/modoboa/locale/en/LC_MESSAGES/django.po
@@ -96,7 +96,7 @@ msgid "Server address"
 msgstr ""
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
 msgstr ""
 
 #: core/app_settings.py:88

--- a/modoboa/locale/es/LC_MESSAGES/django.po
+++ b/modoboa/locale/es/LC_MESSAGES/django.po
@@ -100,7 +100,7 @@ msgid "Server address"
 msgstr "Dirección del servidor"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
 msgstr "La dirección IP del servidor de nombres (DNS) del servidor LDAP"
 
 #: core/app_settings.py:88

--- a/modoboa/locale/fr/LC_MESSAGES/django.po
+++ b/modoboa/locale/fr/LC_MESSAGES/django.po
@@ -101,7 +101,7 @@ msgid "Server address"
 msgstr "Adresse du serveur"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
 msgstr "L'adresse IP ou le nom DNS du serveur LDAP"
 
 #: core/app_settings.py:88

--- a/modoboa/locale/it/LC_MESSAGES/django.po
+++ b/modoboa/locale/it/LC_MESSAGES/django.po
@@ -100,7 +100,7 @@ msgid "Server address"
 msgstr "Indirizzo del server"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
 msgstr "L'indirizzo IP associato al DNS name del server LDAP"
 
 #: core/app_settings.py:88

--- a/modoboa/locale/nl_NL/LC_MESSAGES/django.po
+++ b/modoboa/locale/nl_NL/LC_MESSAGES/django.po
@@ -103,8 +103,8 @@ msgid "Server address"
 msgstr "Server adres"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
-msgstr "Het IP adres en de DNS naam van LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
+msgstr "Het IP adres of de DNS naam van LDAP server"
 
 #: core/app_settings.py:88
 msgid "Server port"

--- a/modoboa/locale/pt_BR/LC_MESSAGES/django.po
+++ b/modoboa/locale/pt_BR/LC_MESSAGES/django.po
@@ -104,7 +104,7 @@ msgid "Server address"
 msgstr "Endereço do servidor"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
 msgstr "O endereço IP do nome DNS do servidor LDAP"
 
 #: core/app_settings.py:88

--- a/modoboa/locale/pt_PT/LC_MESSAGES/django.po
+++ b/modoboa/locale/pt_PT/LC_MESSAGES/django.po
@@ -105,7 +105,7 @@ msgid "Server address"
 msgstr "Endereço do Servidor"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
 msgstr "O endereço IP do servidor de DNS do servidor LDAP"
 
 #: core/app_settings.py:88

--- a/modoboa/locale/ru/LC_MESSAGES/django.po
+++ b/modoboa/locale/ru/LC_MESSAGES/django.po
@@ -99,7 +99,7 @@ msgid "Server address"
 msgstr "Адрес сервера"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
 msgstr "IP адрес или DNS имя сервера LDAP"
 
 #: core/app_settings.py:88

--- a/modoboa/locale/sv/LC_MESSAGES/django.po
+++ b/modoboa/locale/sv/LC_MESSAGES/django.po
@@ -104,7 +104,7 @@ msgid "Server address"
 msgstr "Server adress"
 
 #: core/app_settings.py:83
-msgid "The IP address of the DNS name of the LDAP server"
+msgid "The IP address or the DNS name of the LDAP server"
 msgstr "IP adressen eller DNS namn för LDAP server"
 
 #: core/app_settings.py:88


### PR DESCRIPTION
Fix typo in help text and all corresponding translations' msgids, also fix translation of that item in German and Dutch.

Revise German translation.