### PR TITLE
Fix invalid path for settings.css

### DIFF
--- a/modoboa/core/templates/core/settings_header.html
+++ b/modoboa/core/templates/core/settings_header.html
@@ -5,7 +5,7 @@
 {% block pagetitle %}{% trans "Modoboa settings" %}{% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" type="text/css" href="{% static 'admin/css/settings.css' %}" />
+<link rel="stylesheet" type="text/css" href="{% static 'modoboa_admin/css/settings.css' %}" />
 <link rel="stylesheet" type="text/css" href="{% static 'css/jquery.sortable.css' %}" />
 {% endblock %}
 


### PR DESCRIPTION
The path to settings.css seems to be invalid in settings_headers.html template.