### PR TITLE
Correct INSTALLED_APPS in devmode

### DIFF
--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -48,7 +48,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.staticfiles',
     'reversion',
-    'rest_framework.authtoken'
+    'rest_framework.authtoken',
 {% if devmode %}    'djangobower',{% endif %}
 )
 


### PR DESCRIPTION
PR #794 inadvertently missed a comma that results in, when devmode is set, a dependency of 'authtokendjangobower' attempting to be installed.
This splits that into the two dependencies it was meant to be.