### PR TITLE
Fix swagger app name in INSTALLED_APPS

### DIFF
--- a/doc/getting_started/upgrade.rst
+++ b/doc/getting_started/upgrade.rst
@@ -53,7 +53,7 @@ Specific upgrade instructions
 =====
 
 The API has been greatly improved and a documentation is now
-available. To enable it, add ``'rest_framework.swagger'`` to the
+available. To enable it, add ``'rest_framework_swagger'`` to the
 ``INSTALLED_APPS`` variable in :file:`settings.py` as follows::
 
   INSTALLED_APPS = (

--- a/modoboa/core/commands/templates/settings.py.tpl
+++ b/modoboa/core/commands/templates/settings.py.tpl
@@ -49,7 +49,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'reversion',
     'rest_framework.authtoken',
-    'rest_framework.swagger',
+    'rest_framework_swagger',
 {% if devmode %}    'djangobower',{% endif %}
 )
 


### PR DESCRIPTION
Hi,
there is a typo in the swagger's module name - `.` instead of `_`.