### PR TITLE
allow to use tox to run tests/serve locally in an easy way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*~$
 *.pyc
 *.mo
+modoboa_test.db
 modoboa.egg-info
 doc/.build
 doc/.static

--- a/modoboa/admin/tests/test_account.py
+++ b/modoboa/admin/tests/test_account.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from unittest import skipIf
+
 from django.core.urlresolvers import reverse
 from django.test import override_settings
 
@@ -7,6 +9,7 @@ from modoboa.core.models import User
 from modoboa.core import tests as core_tests
 from modoboa.lib import parameters
 from modoboa.lib.tests import ModoTestCase
+from modoboa.lib.tests import NO_LDAP
 
 from .. import factories
 from .. import models
@@ -171,6 +174,7 @@ class AccountTestCase(ModoTestCase):
         self.assertIn("Resources usage", response.content)
 
 
+@skipIf(NO_LDAP, 'No ldap module installed')
 @override_settings(AUTHENTICATION_BACKENDS=(
     'modoboa.lib.authbackends.LDAPBackend',
     'modoboa.lib.authbackends.SimpleBackend',

--- a/modoboa/core/tests.py
+++ b/modoboa/core/tests.py
@@ -1,5 +1,7 @@
 """Tests for core application."""
 
+from unittest import skipIf
+
 import httmock
 
 from django.core import management
@@ -9,6 +11,7 @@ from django.test import override_settings
 from modoboa.lib import exceptions
 from modoboa.lib import parameters
 from modoboa.lib.tests import ModoTestCase
+from modoboa.lib.tests import NO_LDAP
 
 from . import factories
 from . import mocks
@@ -44,6 +47,7 @@ class AuthenticationTestCase(ModoTestCase):
         self.assertTrue(response.url.endswith(reverse("admin:domain_list")))
 
 
+@skipIf(NO_LDAP, 'No ldap module installed')
 class LDAPTestCaseMixin(object):
     """Set of methods used to test LDAP features."""
 

--- a/modoboa/lib/tests.py
+++ b/modoboa/lib/tests.py
@@ -13,6 +13,12 @@ from rest_framework.test import APITestCase
 from modoboa.lib import parameters
 from modoboa.core import models as core_models
 
+try:
+    import ldap  # NOQA
+    NO_LDAP = False
+except ImportError:
+    NO_LDAP = True
+
 
 class ModoTestCase(TestCase):
 

--- a/modoboa/test_settings.py
+++ b/modoboa/test_settings.py
@@ -21,6 +21,18 @@ if DB == 'MYSQL':
         },
 
     }
+if DB == 'SQLITE':
+    DATABASES = {
+
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'modoboa_test.db',
+            'PORT': '',
+            'ATOMIC_REQUESTS': True,
+
+        },
+
+    }
 else:
     DATABASES = {
 

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -14,7 +14,7 @@ from logging.handlers import SysLogHandler
 
 from django.conf import global_settings
 
-from modoboa.test_settings import *
+from modoboa.test_settings import *  # NOQA
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -26,12 +26,13 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 SECRET_KEY = '!8o(-dbbl3e+*bh7nx-^xysdt)1gso*%@4ze4-9_9o+i&amp;t--u_'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = 'DEBUG' in os.environ
 
-TEMPLATE_DEBUG = False
+TEMPLATE_DEBUG = DEBUG
 
 ALLOWED_HOSTS = [
-    'localhost'
+    '127.0.0.1',
+    'localhost',
 ]
 
 SITE_ID = 1
@@ -112,7 +113,7 @@ USE_TZ = True
 STATIC_URL = '/sitestatic/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'sitestatic')
 STATICFILES_DIRS = (
-    '/home/tonio/.pythonenvs/modoboa/lib/python2.7/site-packages/modoboa-1.3.3-py2.7.egg/modoboa/bower_components',
+    os.path.join(BASE_DIR, '..', 'modoboa', 'bower_components'),
 )
 
 MEDIA_URL = '/media/'
@@ -130,9 +131,9 @@ REST_FRAMEWORK = {
 }
 
 # Modoboa settings
-#MODOBOA_CUSTOM_LOGO = os.path.join(MEDIA_URL, "custom_logo.png")
+# MODOBOA_CUSTOM_LOGO = os.path.join(MEDIA_URL, "custom_logo.png")
 
-#DOVECOT_LOOKUP_PATH = ('/path/to/dovecot', )
+# DOVECOT_LOOKUP_PATH = ('/path/to/dovecot', )
 
 MODOBOA_API_URL = 'http://api.modoboa.org/1/'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+envlist = py27
+
+[testenv]
+changedir=test_project
+commands =
+    python ../tests.py
+    coverage run --source ../modoboa manage.py test modoboa.core modoboa.lib modoboa.admin.tests modoboa.limits modoboa.relaydomains
+deps =
+    -r{toxinidir}/test-requirements.txt
+    coverage
+    psycopg2
+setenv =
+    DB=SQLITE
+
+[testenv:serve]
+changedir=test_project
+commands =
+    python manage.py migrate --no-input
+    python manage.py runserver
+setenv =
+    DB=SQLITE
+    DEBUG=1

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ commands =
 deps =
     -r{toxinidir}/test-requirements.txt
     coverage
-    psycopg2
 setenv =
     DB=SQLITE
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,10 @@ setenv =
 changedir=test_project
 commands =
     python manage.py migrate --no-input
+    python manage.py load_initial_data
+    python -c "import django; django.setup(); from modoboa.admin.factories import populate_database; populate_database()"
     python manage.py runserver
 setenv =
+    DJANGO_SETTINGS_MODULE=test_project.settings
     DB=SQLITE
     DEBUG=1


### PR DESCRIPTION
This allow to use tox locally with sqlite (no ldap/postgres/complex stuff). This may ease contributions!

The only thing missing is a few fixtures so you can login when using tox -e serve. Any idea how to do that ? I guess you already have some code for that at least for testing.